### PR TITLE
Fix chap02 euro12 answer

### DIFF
--- a/02_Filtering_&_Sorting/Euro12/Exercises_with_Solutions.ipynb
+++ b/02_Filtering_&_Sorting/Euro12/Exercises_with_Solutions.ipynb
@@ -1566,7 +1566,7 @@
     "# use .iloc to slices via the position of the passed integers\n",
     "# : means all, 0:7 means from 0 to 7\n",
     "\n",
-    "euro.iloc[: , 0:7]"
+    "euro12.iloc[: , 0:7]"
    ]
   },
   {

--- a/02_Filtering_&_Sorting/Euro12/Exercises_with_Solutions.ipynb
+++ b/02_Filtering_&_Sorting/Euro12/Exercises_with_Solutions.ipynb
@@ -2106,7 +2106,7 @@
    "source": [
     "# use negative to exclude the last 3 columns\n",
     "\n",
-    "euro.iloc[: , :-3]"
+    "euro12.iloc[: , :-3]"
    ]
   },
   {


### PR DESCRIPTION
Fixed 2 typo.
Couldn't find no var named "euro" in the notebook, but found "euro12".
