### PR TITLE
Fix Apply_04/US_Crime_Rates/Exercises_with_solutions Step 8 and Step 9 .

### DIFF
--- a/04_Apply/US_Crime_Rates/Exercises_with_solutions.ipynb
+++ b/04_Apply/US_Crime_Rates/Exercises_with_solutions.ipynb
@@ -22,10 +22,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -48,15 +46,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 265,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -171,7 +180,7 @@
        "4   130390              203050   1213200        2514400         472800  "
       ]
      },
-     "execution_count": 265,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,10 +200,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 266,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -203,20 +210,22 @@
       "<class 'pandas.core.frame.DataFrame'>\n",
       "RangeIndex: 55 entries, 0 to 54\n",
       "Data columns (total 12 columns):\n",
-      "Year                  55 non-null int64\n",
-      "Population            55 non-null int64\n",
-      "Total                 55 non-null int64\n",
-      "Violent               55 non-null int64\n",
-      "Property              55 non-null int64\n",
-      "Murder                55 non-null int64\n",
-      "Forcible_Rape         55 non-null int64\n",
-      "Robbery               55 non-null int64\n",
-      "Aggravated_assault    55 non-null int64\n",
-      "Burglary              55 non-null int64\n",
-      "Larceny_Theft         55 non-null int64\n",
-      "Vehicle_Theft         55 non-null int64\n",
+      " #   Column              Non-Null Count  Dtype\n",
+      "---  ------              --------------  -----\n",
+      " 0   Year                55 non-null     int64\n",
+      " 1   Population          55 non-null     int64\n",
+      " 2   Total               55 non-null     int64\n",
+      " 3   Violent             55 non-null     int64\n",
+      " 4   Property            55 non-null     int64\n",
+      " 5   Murder              55 non-null     int64\n",
+      " 6   Forcible_Rape       55 non-null     int64\n",
+      " 7   Robbery             55 non-null     int64\n",
+      " 8   Aggravated_assault  55 non-null     int64\n",
+      " 9   Burglary            55 non-null     int64\n",
+      " 10  Larceny_Theft       55 non-null     int64\n",
+      " 11  Vehicle_Theft       55 non-null     int64\n",
       "dtypes: int64(12)\n",
-      "memory usage: 5.2 KB\n"
+      "memory usage: 5.3 KB\n"
      ]
     }
    ],
@@ -235,10 +244,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 267,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -247,20 +254,22 @@
       "<class 'pandas.core.frame.DataFrame'>\n",
       "RangeIndex: 55 entries, 0 to 54\n",
       "Data columns (total 12 columns):\n",
-      "Year                  55 non-null datetime64[ns]\n",
-      "Population            55 non-null int64\n",
-      "Total                 55 non-null int64\n",
-      "Violent               55 non-null int64\n",
-      "Property              55 non-null int64\n",
-      "Murder                55 non-null int64\n",
-      "Forcible_Rape         55 non-null int64\n",
-      "Robbery               55 non-null int64\n",
-      "Aggravated_assault    55 non-null int64\n",
-      "Burglary              55 non-null int64\n",
-      "Larceny_Theft         55 non-null int64\n",
-      "Vehicle_Theft         55 non-null int64\n",
+      " #   Column              Non-Null Count  Dtype         \n",
+      "---  ------              --------------  -----         \n",
+      " 0   Year                55 non-null     datetime64[ns]\n",
+      " 1   Population          55 non-null     int64         \n",
+      " 2   Total               55 non-null     int64         \n",
+      " 3   Violent             55 non-null     int64         \n",
+      " 4   Property            55 non-null     int64         \n",
+      " 5   Murder              55 non-null     int64         \n",
+      " 6   Forcible_Rape       55 non-null     int64         \n",
+      " 7   Robbery             55 non-null     int64         \n",
+      " 8   Aggravated_assault  55 non-null     int64         \n",
+      " 9   Burglary            55 non-null     int64         \n",
+      " 10  Larceny_Theft       55 non-null     int64         \n",
+      " 11  Vehicle_Theft       55 non-null     int64         \n",
       "dtypes: datetime64[ns](1), int64(11)\n",
-      "memory usage: 5.2 KB\n"
+      "memory usage: 5.3 KB\n"
      ]
     }
    ],
@@ -279,15 +288,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 268,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -420,7 +440,7 @@
        "1964-01-01         472800  "
       ]
      },
-     "execution_count": 268,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -439,15 +459,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 269,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -565,7 +596,7 @@
        "1964-01-01              203050   1213200        2514400         472800  "
       ]
      },
-     "execution_count": 269,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -586,9 +617,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 270,
+   "execution_count": 7,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -596,6 +626,19 @@
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -611,10 +654,23 @@
        "      <th>Larceny_Theft</th>\n",
        "      <th>Vehicle_Theft</th>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Year</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1960</th>\n",
+       "      <th>1960-01-01</th>\n",
        "      <td>201385000</td>\n",
        "      <td>4134930</td>\n",
        "      <td>45160900</td>\n",
@@ -627,7 +683,7 @@
        "      <td>5292100</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1970</th>\n",
+       "      <th>1970-01-01</th>\n",
        "      <td>220099000</td>\n",
        "      <td>9607930</td>\n",
        "      <td>91383800</td>\n",
@@ -640,7 +696,7 @@
        "      <td>9739900</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1980</th>\n",
+       "      <th>1980-01-01</th>\n",
        "      <td>248239000</td>\n",
        "      <td>14074328</td>\n",
        "      <td>117048900</td>\n",
@@ -653,7 +709,7 @@
        "      <td>11935411</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1990</th>\n",
+       "      <th>1990-01-01</th>\n",
        "      <td>272690813</td>\n",
        "      <td>17527048</td>\n",
        "      <td>119053499</td>\n",
@@ -666,7 +722,7 @@
        "      <td>14624418</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2000</th>\n",
+       "      <th>2000-01-01</th>\n",
        "      <td>307006550</td>\n",
        "      <td>13968056</td>\n",
        "      <td>100944369</td>\n",
@@ -679,7 +735,7 @@
        "      <td>11412834</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2010</th>\n",
+       "      <th>2010-01-01</th>\n",
        "      <td>318857056</td>\n",
        "      <td>6072017</td>\n",
        "      <td>44095950</td>\n",
@@ -696,24 +752,26 @@
        "</div>"
       ],
       "text/plain": [
-       "      Population   Violent   Property  Murder  Forcible_Rape  Robbery  \\\n",
-       "1960   201385000   4134930   45160900  106180         236720  1633510   \n",
-       "1970   220099000   9607930   91383800  192230         554570  4159020   \n",
-       "1980   248239000  14074328  117048900  206439         865639  5383109   \n",
-       "1990   272690813  17527048  119053499  211664         998827  5748930   \n",
-       "2000   307006550  13968056  100944369  163068         922499  4230366   \n",
-       "2010   318857056   6072017   44095950   72867         421059  1749809   \n",
+       "            Population   Violent   Property  Murder  Forcible_Rape  Robbery  \\\n",
+       "Year                                                                          \n",
+       "1960-01-01   201385000   4134930   45160900  106180         236720  1633510   \n",
+       "1970-01-01   220099000   9607930   91383800  192230         554570  4159020   \n",
+       "1980-01-01   248239000  14074328  117048900  206439         865639  5383109   \n",
+       "1990-01-01   272690813  17527048  119053499  211664         998827  5748930   \n",
+       "2000-01-01   307006550  13968056  100944369  163068         922499  4230366   \n",
+       "2010-01-01   318857056   6072017   44095950   72867         421059  1749809   \n",
        "\n",
-       "      Aggravated_assault  Burglary  Larceny_Theft  Vehicle_Theft  \n",
-       "1960             2158520  13321100       26547700        5292100  \n",
-       "1970             4702120  28486000       53157800        9739900  \n",
-       "1980             7619130  33073494       72040253       11935411  \n",
-       "1990            10568963  26750015       77679366       14624418  \n",
-       "2000             8652124  21565176       67970291       11412834  \n",
-       "2010             3764142  10125170       30401698        3569080  "
+       "            Aggravated_assault  Burglary  Larceny_Theft  Vehicle_Theft  \n",
+       "Year                                                                    \n",
+       "1960-01-01             2158520  13321100       26547700        5292100  \n",
+       "1970-01-01             4702120  28486000       53157800        9739900  \n",
+       "1980-01-01             7619130  33073494       72040253       11935411  \n",
+       "1990-01-01            10568963  26750015       77679366       14624418  \n",
+       "2000-01-01             8652124  21565176       67970291       11412834  \n",
+       "2010-01-01             3764142  10125170       30401698        3569080  "
       ]
      },
-     "execution_count": 270,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -743,58 +801,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 276,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Population            2010\n",
-       "Violent               1990\n",
-       "Property              1990\n",
-       "Murder                1990\n",
-       "Forcible_Rape         1990\n",
-       "Robbery               1990\n",
-       "Aggravated_assault    1990\n",
-       "Burglary              1980\n",
-       "Larceny_Theft         1990\n",
-       "Vehicle_Theft         1990\n",
-       "dtype: int64"
+       "Population           2010-01-01\n",
+       "Violent              1990-01-01\n",
+       "Property             1990-01-01\n",
+       "Murder               1990-01-01\n",
+       "Forcible_Rape        1990-01-01\n",
+       "Robbery              1990-01-01\n",
+       "Aggravated_assault   1990-01-01\n",
+       "Burglary             1980-01-01\n",
+       "Larceny_Theft        1990-01-01\n",
+       "Vehicle_Theft        1990-01-01\n",
+       "dtype: datetime64[ns]"
       ]
      },
-     "execution_count": 276,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# apparently the 90s was a pretty dangerous time in the US\n",
-    "crime.idxmax(0)"
+    "crimes.idxmax(0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION

Step 8 solution is in 1960-1-1 format instead of 1960.

Step 9 solution is 'crimes.idxmax (0)' instead of 'crime.idxmax (0)'.