### PR TITLE
Update 02_Filtering_&_Sorting/Chipotle/Exercises_with_solutions.ipynb (correct the step 9)

### DIFF
--- a/02_Filtering_&_Sorting/Chipotle/Exercises_with_solutions.ipynb
+++ b/02_Filtering_&_Sorting/Chipotle/Exercises_with_solutions.ipynb
@@ -2192,8 +2192,10 @@
     }
    ],
    "source": [
-    "chipo_drink_steak_bowl = chipo[(chipo.item_name == \"Canned Soda\") & (chipo.quantity > 1)]\n",
-    "len(chipo_drink_steak_bowl)"
+    "chipo_canned_soda = chipo[chipo.item_name == \"Canned Soda\"]\n",
+    "chipo_canned_soda_order_count = chipo_canned_soda.groupby(\"order_id\").sum()\n",
+    "chipo_canned_soda_chosed = chipo_canned_soda_order_count[chipo_canned_soda_order_count['quantity']>1]\n",
+    "len(chipo_drink_count)"
    ]
   }
  ],

--- a/02_Filtering_&_Sorting/Chipotle/Exercises_with_solutions.ipynb
+++ b/02_Filtering_&_Sorting/Chipotle/Exercises_with_solutions.ipynb
@@ -2195,7 +2195,7 @@
     "chipo_canned_soda = chipo[chipo.item_name == \"Canned Soda\"]\n",
     "chipo_canned_soda_order_count = chipo_canned_soda.groupby(\"order_id\").sum()\n",
     "chipo_canned_soda_chosed = chipo_canned_soda_order_count[chipo_canned_soda_order_count['quantity']>1]\n",
-    "len(chipo_drink_count)"
+    "len(chipo_canned_soda_chosed)"
    ]
   }
  ],


### PR DESCRIPTION
Step 9: there are 4 orders which ordered canned soda more than one time, but only one can one time. 
(these four orders are orders whose order_id= 81,108,496,1396)
So, if only counts the quantity will ignore these orders