### PR TITLE
Fix: Exercise_with_Solutions.ipynb, a slight fix at the step 16 [Getting and knowing your data]

### DIFF
--- a/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
+++ b/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
@@ -737,7 +737,7 @@
     "\n",
     "chipo['revenue'] = chipo['quantity'] * chipo['item_price']\n",
     "order_grouped = chipo.groupby(by=['order_id']).sum()\n",
-    "order_grouped.mean()['revenue']"
+    "order_grouped['revenue'].mean()"
    ]
   },
   {
@@ -761,7 +761,7 @@
    "source": [
     "# Solution 2\n",
     "\n",
-    "chipo.groupby(by=['order_id']).sum().mean()['revenue']"
+    "chipo.groupby(by=['order_id']).sum()['revenue'].mean()"
    ]
   },
   {


### PR DESCRIPTION
### Step 16:
we could not get the mean from all of the columns in order_group (some of them are string), so we need to select column 'revenue' first and then get the mean from them.

![image](https://github.com/guipsamora/pandas_exercises/assets/103496001/0c63003c-2ae1-4ed1-96f6-300b1c753d31)
![image](https://github.com/guipsamora/pandas_exercises/assets/103496001/e3b0eb28-d5bf-4d14-845b-28786d29485e)
