### PR TITLE
Fix TypeError in Step 6 by adding numeric_only=True to groupby.mean()

### DIFF
--- a/03_Grouping/Alcohol_Consumption/Exercise_with_solutions.ipynb
+++ b/03_Grouping/Alcohol_Consumption/Exercise_with_solutions.ipynb
@@ -341,7 +341,7 @@
     }
    ],
    "source": [
-    "drinks.groupby('continent').mean()"
+    "drinks.groupby('continent').mean(numeric_only=True)"
    ]
   },
   {


### PR DESCRIPTION
### Issue
In `03_Grouping/Alcohol_Consumption/Exercise_with_solutions.ipynb`, Step 6 (`drinks.groupby('continent').mean()`) raises a `TypeError` in modern pandas versions (e.g., 2.x) due to attempting to compute the mean of the non-numeric `country` column.

### Fix
Updated the code to `drinks.groupby('continent').mean(numeric_only=True)` to exclude non-numeric columns, ensuring compatibility with pandas 2.x.

### Impact
This fixes the error and aligns the solution with current pandas behavior, improving the exercise for learners.