### PR TITLE
Fix: Remove extra "order_id" sum and make output clean for "Most Popular Item".

### DIFF
--- a/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
+++ b/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
@@ -77,6 +77,19 @@
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -253,13 +266,15 @@
       "<class 'pandas.core.frame.DataFrame'>\n",
       "RangeIndex: 4622 entries, 0 to 4621\n",
       "Data columns (total 5 columns):\n",
-      "order_id              4622 non-null int64\n",
-      "quantity              4622 non-null int64\n",
-      "item_name             4622 non-null object\n",
-      "choice_description    3376 non-null object\n",
-      "item_price            4622 non-null object\n",
+      " #   Column              Non-Null Count  Dtype \n",
+      "---  ------              --------------  ----- \n",
+      " 0   order_id            4622 non-null   int64 \n",
+      " 1   quantity            4622 non-null   int64 \n",
+      " 2   item_name           4622 non-null   object\n",
+      " 3   choice_description  3376 non-null   object\n",
+      " 4   item_price          4622 non-null   object\n",
       "dtypes: int64(2), object(3)\n",
-      "memory usage: 180.6+ KB\n"
+      "memory usage: 180.7+ KB\n"
      ]
     }
    ],
@@ -315,8 +330,8 @@
     {
      "data": {
       "text/plain": [
-       "Index([u'order_id', u'quantity', u'item_name', u'choice_description',\n",
-       "       u'item_price'],\n",
+       "Index(['order_id', 'quantity', 'item_name', 'choice_description',\n",
+       "       'item_price'],\n",
        "      dtype='object')"
       ]
      },
@@ -376,23 +391,33 @@
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>order_id</th>\n",
        "      <th>quantity</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>item_name</th>\n",
-       "      <th></th>\n",
        "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>Chicken Bowl</th>\n",
-       "      <td>713926</td>\n",
        "      <td>761</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -400,9 +425,9 @@
        "</div>"
       ],
       "text/plain": [
-       "              order_id  quantity\n",
-       "item_name                       \n",
-       "Chicken Bowl    713926       761"
+       "              quantity\n",
+       "item_name             \n",
+       "Chicken Bowl       761"
       ]
      },
      "execution_count": 9,
@@ -411,7 +436,7 @@
     }
    ],
    "source": [
-    "c = chipo.groupby('item_name')\n",
+    "c = chipo[['item_name','quantity']].groupby('item_name')\n",
     "c = c.sum()\n",
     "c = c.sort_values(['quantity'], ascending=False)\n",
     "c.head(1)"
@@ -797,21 +822,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "mo_aval",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
+++ b/01_Getting_&_Knowing_Your_Data/Chipotle/Exercise_with_Solutions.ipynb
@@ -460,23 +460,33 @@
      "data": {
       "text/html": [
        "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>order_id</th>\n",
        "      <th>quantity</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>item_name</th>\n",
-       "      <th></th>\n",
        "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>Chicken Bowl</th>\n",
-       "      <td>713926</td>\n",
        "      <td>761</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -484,9 +494,9 @@
        "</div>"
       ],
       "text/plain": [
-       "              order_id  quantity\n",
-       "item_name                       \n",
-       "Chicken Bowl    713926       761"
+       "              quantity\n",
+       "item_name             \n",
+       "Chicken Bowl       761"
       ]
      },
      "execution_count": 10,
@@ -495,7 +505,7 @@
     }
    ],
    "source": [
-    "c = chipo.groupby('item_name')\n",
+    "c = chipo[['item_name','quantity']].groupby('item_name')\n",
     "c = c.sum()\n",
     "c = c.sort_values(['quantity'], ascending=False)\n",
     "c.head(1)"


### PR DESCRIPTION
### **Description**

#### Problem:
The code for finding the most popular item used in the solution:
```python
c = chipo.groupby('item_name')
c = c.sum()
c = c.sort_values(['quantity'], ascending=False)
c.head(1)
```
<img width="712" height="116" alt="image" src="https://github.com/user-attachments/assets/985767d6-5827-414b-8542-998212c6df1d" />

This caused problems:
- It added all columns, including 'order_id'. Even though the expected answer shows an 'order_id' column, it only displays the sum of order Ids, which has no real meaning.
- The result **doesn't match** the expected output in the solution.

#### Fixed:
The code now only uses 'item_name' and 'quantity' before grouping and summing:
```python
c = chipo[['item_name','quantity']].groupby('item_name')
c = c.sum()
c = c.sort_values(['quantity'], ascending=False)
c.head(1)
```
<img width="791" height="114" alt="image" src="https://github.com/user-attachments/assets/2a6e6050-7d28-4f17-812b-67146093b892" />
